### PR TITLE
Add SwiftUI color picker game scaffolding

### DIFF
--- a/ColorPickerGame/.gitignore
+++ b/ColorPickerGame/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ColorPickerGame/Package.swift
+++ b/ColorPickerGame/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ColorPickerGame",
+    platforms: [
+        .iOS(.v15)
+    ],
+    targets: [
+        .executableTarget(
+            name: "ColorPickerGame"
+        ),
+    ]
+)

--- a/ColorPickerGame/Sources/ColorPickerGame/ColorPickerGameApp.swift
+++ b/ColorPickerGame/Sources/ColorPickerGame/ColorPickerGameApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ColorPickerGameApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ColorPickerGame/Sources/ColorPickerGame/ContentView.swift
+++ b/ColorPickerGame/Sources/ColorPickerGame/ContentView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = GameViewModel()
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(viewModel.targetColor)
+                .frame(width: 200, height: 200)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.black, lineWidth: 2)
+                )
+            ColorPicker("Select a color", selection: $viewModel.selectedColor)
+                .padding()
+            Button("New Color") {
+                viewModel.newRound()
+            }
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/ColorPickerGame/Sources/ColorPickerGame/GameViewModel.swift
+++ b/ColorPickerGame/Sources/ColorPickerGame/GameViewModel.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+final class GameViewModel: ObservableObject {
+    @Published var targetColor: Color = .red
+    @Published var selectedColor: Color = .white
+    
+    init() {
+        newRound()
+    }
+    
+    func newRound() {
+        targetColor = Color(
+            red: .random(in: 0...1),
+            green: .random(in: 0...1),
+            blue: .random(in: 0...1)
+        )
+        selectedColor = .white
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # hue_knew
-mobile app game for teaching players the names of obscure colors
+mobile app game for teaching players the names of obscure colors.
+
+## Color Picker Game Scaffolding
+
+The `ColorPickerGame` directory contains a Swift package with the
+initial SwiftUI scaffolding for a color picker guessing game. The app
+displays a randomly generated color and allows players to pick a color
+using `ColorPicker`. Press the **New Color** button to start a new
+round with a different target color.
+
+To build and run with Xcode:
+
+```bash
+open ColorPickerGame/Package.swift
+```
+
+Then select the `ColorPickerGame` scheme for an iOS simulator.


### PR DESCRIPTION
## Summary
- add a Swift package `ColorPickerGame` with SwiftUI scaffolding
- document how to build and run the example in the README

## Testing
- `swift package describe`
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6864767f2fe083308ce628b935020586