### PR TITLE
Auto-progress to next challenge

### DIFF
--- a/HueKnew/Views/ChallengeView.swift
+++ b/HueKnew/Views/ChallengeView.swift
@@ -16,6 +16,10 @@ struct ChallengeView: View {
     @State private var showingResult = false
     @State private var answerOptions: [ColorInfo] = []
     @State private var targetColor: ColorInfo?
+
+    /// Delay before automatically advancing to the next challenge after
+    /// showing the result.
+    private let autoAdvanceDelay: TimeInterval = 1.5
     
     var body: some View {
         ZStack {
@@ -195,22 +199,14 @@ struct ChallengeView: View {
             .background(Color(.systemGray6))
             .cornerRadius(12)
             
-            // Continue button
-            Button(action: {
-                onAnswerSelected(isCorrect)
-            }) {
-                Text("Continue")
-                    .font(.title2)
-                    .fontWeight(.bold)
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.blue)
-                    .cornerRadius(12)
-            }
-            .padding(.horizontal)
         }
         .animation(.easeInOut(duration: 0.5), value: showingResult)
+        .onAppear {
+            // Automatically move to the next challenge after a short delay.
+            DispatchQueue.main.asyncAfter(deadline: .now() + autoAdvanceDelay) {
+                onAnswerSelected(isCorrect)
+            }
+        }
     }
     
     private func setupChallenge() {


### PR DESCRIPTION
## Summary
- remove Continue button in `ChallengeView`
- add automatic progression to the next challenge after displaying the result

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68741a590e9483309bdd5b26768e32ca