### PR TITLE
Display build number in Settings

### DIFF
--- a/HueKnew/Views/SettingsView.swift
+++ b/HueKnew/Views/SettingsView.swift
@@ -11,6 +11,12 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var audioManager = AudioManager.shared
     @State private var showingResetAlert = false
+
+    private var versionString: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        return "\(version) (build \(build))"
+    }
     
     let gameModel: GameModel
     
@@ -38,7 +44,7 @@ struct SettingsView: View {
                     HStack {
                         Text("Version")
                         Spacer()
-                        Text("1.0.0")
+                        Text(versionString)
                             .foregroundColor(.secondary)
                     }
                     

--- a/HueKnew/Views/SettingsView.swift
+++ b/HueKnew/Views/SettingsView.swift
@@ -12,9 +12,12 @@ struct SettingsView: View {
     @StateObject private var audioManager = AudioManager.shared
     @State private var showingResetAlert = false
 
+    private static let versionKey = "CFBundleShortVersionString"
+    private static let buildKey = "CFBundleVersion"
+
     private var versionString: String {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
-        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        let version = Bundle.main.infoDictionary?[Self.versionKey] as? String ?? "1.0"
+        let build = Bundle.main.infoDictionary?[Self.buildKey] as? String ?? "1"
         return "\(version) (build \(build))"
     }
     


### PR DESCRIPTION
## Summary
- show the app build number alongside the version in Settings

## Testing
- `xcodebuild test -project HueKnew.xcodeproj -scheme HueKnew -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68745dd55b288330a12bed67066b7255