### PR TITLE
Remove gray box from challenge question

### DIFF
--- a/HueKnew/Views/ChallengeView.swift
+++ b/HueKnew/Views/ChallengeView.swift
@@ -84,14 +84,12 @@ struct ChallengeView: View {
             case .nameToColor:
                 // Show color name, ask to pick color
                 VStack(spacing: 8) {
-                    
+
                     Text(targetColor?.name ?? "")
                         .font(.largeTitle)
                         .fontWeight(.bold)
                         .foregroundColor(.orange)
                         .padding()
-                        .background(Color(.systemGray6))
-                        .cornerRadius(12)
                 }
                 
             case .colorToName:
@@ -108,8 +106,6 @@ struct ChallengeView: View {
             }
         }
         .padding()
-        .background(Color(.systemGray6))
-        .cornerRadius(16)
         .padding(.horizontal)
     }
     


### PR DESCRIPTION
## Summary
- tweak ChallengeView to eliminate the gray background around the question prompt

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687466c456d08330841fd3ea0b45891d