### PR TITLE
Add similar color suggestions

### DIFF
--- a/HueKnew/Data/ColorDatabase.swift
+++ b/HueKnew/Data/ColorDatabase.swift
@@ -288,6 +288,8 @@ extension ColorDatabase {
     }
 
     func getMostSimilarColors(to color: ColorInfo, count: Int) -> [ColorInfo] {
+        guard count > 0 else { return [] }
+
         var bestMatches: [(info: ColorInfo, diff: Double)] = []
         let candidates = getAllColors().filter { $0.id != color.id }
 
@@ -295,12 +297,13 @@ extension ColorDatabase {
             let diff = calculateColorDifference(color1: color, color2: candidate)
 
             if bestMatches.count < count {
-                bestMatches.append((candidate, diff))
-                bestMatches.sort { $0.diff < $1.diff }
+                // Insert while maintaining ascending order by difference
+                let index = bestMatches.firstIndex { diff < $0.diff } ?? bestMatches.count
+                bestMatches.insert((candidate, diff), at: index)
             } else if let worst = bestMatches.last, diff < worst.diff {
                 bestMatches.removeLast()
-                bestMatches.append((candidate, diff))
-                bestMatches.sort { $0.diff < $1.diff }
+                let index = bestMatches.firstIndex { diff < $0.diff } ?? bestMatches.count
+                bestMatches.insert((candidate, diff), at: index)
             }
         }
 

--- a/HueKnew/Data/ColorDatabase.swift
+++ b/HueKnew/Data/ColorDatabase.swift
@@ -288,12 +288,23 @@ extension ColorDatabase {
     }
 
     func getMostSimilarColors(to color: ColorInfo, count: Int) -> [ColorInfo] {
-        let allColors = getAllColors().filter { $0.id != color.id }
-        let sorted = allColors.sorted {
-            calculateColorDifference(color1: color, color2: $0) <
-            calculateColorDifference(color1: color, color2: $1)
+        var bestMatches: [(info: ColorInfo, diff: Double)] = []
+        let candidates = getAllColors().filter { $0.id != color.id }
+
+        for candidate in candidates {
+            let diff = calculateColorDifference(color1: color, color2: candidate)
+
+            if bestMatches.count < count {
+                bestMatches.append((candidate, diff))
+                bestMatches.sort { $0.diff < $1.diff }
+            } else if let worst = bestMatches.last, diff < worst.diff {
+                bestMatches.removeLast()
+                bestMatches.append((candidate, diff))
+                bestMatches.sort { $0.diff < $1.diff }
+            }
         }
-        return Array(sorted.prefix(count))
+
+        return bestMatches.map { $0.info }
     }
 
     func getAvailableColors() -> [TSVColor] {

--- a/HueKnew/Data/ColorDatabase.swift
+++ b/HueKnew/Data/ColorDatabase.swift
@@ -287,6 +287,15 @@ extension ColorDatabase {
         return Array(allColors.shuffled().prefix(count))
     }
 
+    func getMostSimilarColors(to color: ColorInfo, count: Int) -> [ColorInfo] {
+        let allColors = getAllColors().filter { $0.id != color.id }
+        let sorted = allColors.sorted {
+            calculateColorDifference(color1: color, color2: $0) <
+            calculateColorDifference(color1: color, color2: $1)
+        }
+        return Array(sorted.prefix(count))
+    }
+
     func getAvailableColors() -> [TSVColor] {
         return tsvColors
     }

--- a/HueKnew/Data/ColorDatabase.swift
+++ b/HueKnew/Data/ColorDatabase.swift
@@ -360,7 +360,7 @@ extension ColorDatabase {
         
         // Compare saturation (relative to color1)
         let satDiff = hsb1.saturation - hsb2.saturation
-        if abs(satDiff) > 0.1 {
+        if abs(satDiff) > 0.05 {
             if satDiff > 0 {
                 comparisons.append("More Saturated")
             } else {
@@ -371,7 +371,7 @@ extension ColorDatabase {
         
         // Compare brightness (relative to color1)
         let brightDiff = hsb1.brightness - hsb2.brightness
-        if abs(brightDiff) > 0.1 {
+        if abs(brightDiff) > 0.05 {
             if brightDiff > 0 {
                 comparisons.append("Brighter")
             } else {
@@ -430,7 +430,7 @@ extension ColorDatabase {
             return "More \(color1.capitalized)"
         } else {
             // Same color family, but different shades
-            if abs(hueDiff) > 20 {
+            if abs(hueDiff) > 2 {
                 if hueDiff > 0 && hueDiff < 180 || hueDiff < -180 {
                     return "More \(color1.capitalized)"
                 } else {

--- a/HueKnew/Data/ColorDatabase.swift
+++ b/HueKnew/Data/ColorDatabase.swift
@@ -360,26 +360,32 @@ extension ColorDatabase {
         
         // Compare saturation (relative to color1)
         let satDiff = hsb1.saturation - hsb2.saturation
-        if abs(satDiff) > 0.05 {
-            if satDiff > 0 {
-                comparisons.append("More Saturated")
+        if abs(satDiff) > 0.02 {
+            if abs(satDiff) > 0.05 {
+                comparisons.append(satDiff > 0 ? "More Saturated" : "Less Saturated")
             } else {
-                comparisons.append("Less Saturated")
+                comparisons.append(satDiff > 0 ? "Slightly More Saturated" : "Slightly Less Saturated")
             }
-            Logger.debug("Added saturation comparison: \(satDiff > 0 ? "More" : "Less") Saturated")
+            Logger.debug("Added saturation comparison: \(satDiff)" )
         }
         
         // Compare brightness (relative to color1)
         let brightDiff = hsb1.brightness - hsb2.brightness
-        if abs(brightDiff) > 0.05 {
-            if brightDiff > 0 {
-                comparisons.append("Brighter")
+        if abs(brightDiff) > 0.02 {
+            if abs(brightDiff) > 0.05 {
+                comparisons.append(brightDiff > 0 ? "Brighter" : "Darker")
             } else {
-                comparisons.append("Darker")
+                comparisons.append(brightDiff > 0 ? "Slightly Brighter" : "Slightly Darker")
             }
-            Logger.debug("Added brightness comparison: \(brightDiff > 0 ? "Brighter" : "Darker")")
+            Logger.debug("Added brightness comparison: \(brightDiff)")
         }
-        
+
+        // Vibrancy indicator
+        if satDiff < -0.05 && brightDiff < -0.02 {
+            comparisons.append("More Muted")
+        } else if satDiff > 0.05 && brightDiff > 0.02 {
+            comparisons.append("More Vibrant")
+        }
         Logger.debug("Final comparisons for \(color1.name): \(comparisons)")
         return comparisons
     }
@@ -425,21 +431,30 @@ extension ColorDatabase {
         
         let color1 = getColorName(for: hue1)
         let color2 = getColorName(for: hue2)
-        
+
+        let adjustedDiff = hueDiff > 180 ? hueDiff - 360 : (hueDiff < -180 ? hueDiff + 360 : hueDiff)
+
         if color1 != color2 {
-            return "More \(color1.capitalized)"
+            return adjustedDiff > 0 ? "More \(color1.capitalized)" : "Less \(color1.capitalized)"
         } else {
-            // Same color family, but different shades
-            if abs(hueDiff) > 2 {
-                if hueDiff > 0 && hueDiff < 180 || hueDiff < -180 {
-                    return "More \(color1.capitalized)"
-                } else {
-                    return "Less \(color1.capitalized)"
-                }
+            guard abs(adjustedDiff) > 1 else { return "" }
+            let neighbor = adjacentColorName(for: color1, direction: adjustedDiff)
+            if abs(adjustedDiff) < 5 {
+                return "Hint of \(neighbor.capitalized)"
+            } else {
+                return "More \(neighbor.capitalized)"
             }
         }
-        
-        return ""
+    }
+
+    private func adjacentColorName(for color: String, direction: Double) -> String {
+        let order = ["red", "orange", "yellow", "green", "blue", "purple", "magenta", "red"]
+        guard let index = order.firstIndex(of: color) else { return color }
+        if direction > 0 {
+            return order[index + 1]
+        } else {
+            return order[index == 0 ? order.count - 2 : index - 1]
+        }
     }
 }
 

--- a/HueKnew/Views/ColorDetailView.swift
+++ b/HueKnew/Views/ColorDetailView.swift
@@ -9,7 +9,12 @@ import SwiftUI
 
 struct ColorDetailView: View {
     let color: ColorInfo
-    
+    private let colorDatabase = ColorDatabase.shared
+
+    private var similarColors: [ColorInfo] {
+        colorDatabase.getMostSimilarColors(to: color, count: 2)
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
@@ -60,6 +65,20 @@ struct ColorDetailView: View {
                 }
                 .padding(.horizontal)
                 .padding(.bottom)
+
+                if !similarColors.isEmpty {
+                    Text("Similar Colors")
+                        .font(.headline)
+                        .padding(.horizontal)
+
+                    HStack(spacing: 16) {
+                        ForEach(similarColors, id: \.id) { similar in
+                            SimilarColorCard(colorInfo: similar, baseColor: color)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.bottom)
+                }
             }
         }
         .navigationTitle(color.name)

--- a/HueKnew/Views/LearningView.swift
+++ b/HueKnew/Views/LearningView.swift
@@ -153,7 +153,7 @@ struct ColorDisplayCard: View {
                             .foregroundColor(.secondary)
                             .accessibilityLabel("No differences found between colors")
                     } else {
-                        ForEach(characteristics, id: \.self) { characteristic in
+                        ForEach(Array(characteristics.enumerated()), id: \.offset) { _, characteristic in
                             HStack(alignment: .top, spacing: 4) {
                                 Text("•")
                                     .font(.caption)

--- a/HueKnew/Views/LearningView.swift
+++ b/HueKnew/Views/LearningView.swift
@@ -148,7 +148,7 @@ struct ColorDisplayCard: View {
                     let characteristics = getComparativeCharacteristics()
                     let otherColor = isPrimaryColor ? colorPair.comparisonColor : colorPair.primaryColor
                     if characteristics.isEmpty {
-                        Text("No differences found")
+                        Text("Identical for human eyes")
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .accessibilityLabel("No differences found between colors")

--- a/HueKnew/Views/SimilarColorCard.swift
+++ b/HueKnew/Views/SimilarColorCard.swift
@@ -21,6 +21,14 @@ struct SimilarColorCard: View {
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
 
+            Text(colorInfo.hexValue)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color(.systemGray5))
+                .cornerRadius(6)
+
             VStack(alignment: .leading, spacing: 2) {
                 let characteristics = ColorDatabase.shared.getColorComparisons(color1: colorInfo, color2: baseColor)
                 if characteristics.isEmpty {

--- a/HueKnew/Views/SimilarColorCard.swift
+++ b/HueKnew/Views/SimilarColorCard.swift
@@ -29,7 +29,7 @@ struct SimilarColorCard: View {
                         .foregroundColor(.secondary)
                         .accessibilityLabel("No differences found between colors")
                 } else {
-                    ForEach(characteristics, id: \.self) { characteristic in
+                    ForEach(Array(characteristics.enumerated()), id: \.offset) { _, characteristic in
                         HStack(alignment: .top, spacing: 4) {
                             Text("•")
                                 .font(.caption)

--- a/HueKnew/Views/SimilarColorCard.swift
+++ b/HueKnew/Views/SimilarColorCard.swift
@@ -32,7 +32,7 @@ struct SimilarColorCard: View {
             VStack(alignment: .leading, spacing: 2) {
                 let characteristics = ColorDatabase.shared.getColorComparisons(color1: colorInfo, color2: baseColor)
                 if characteristics.isEmpty {
-                    Text("No differences found")
+                    Text("Identical for human eyes")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .accessibilityLabel("No differences found between colors")

--- a/HueKnew/Views/SimilarColorCard.swift
+++ b/HueKnew/Views/SimilarColorCard.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct SimilarColorCard: View {
+    let colorInfo: ColorInfo
+    let baseColor: ColorInfo
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Rectangle()
+                .fill(colorInfo.color)
+                .frame(height: 120)
+                .cornerRadius(12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color(.systemGray4), lineWidth: 1)
+                )
+
+            Text(colorInfo.name)
+                .font(.headline)
+                .foregroundColor(.primary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                let characteristics = ColorDatabase.shared.getColorComparisons(color1: colorInfo, color2: baseColor)
+                if characteristics.isEmpty {
+                    Text("No differences found")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .accessibilityLabel("No differences found between colors")
+                } else {
+                    ForEach(characteristics, id: \.self) { characteristic in
+                        HStack(alignment: .top, spacing: 4) {
+                            Text("•")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .accessibilityHidden(true)
+                            Text(characteristic)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.leading)
+                                .lineLimit(1)
+                                .accessibilityLabel("\(colorInfo.name) is \(characteristic.lowercased()) than \(baseColor.name)")
+                        }
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+            }
+            .padding(.horizontal, 4)
+            .padding(.top, 4)
+        }
+        .padding()
+        .background(Color(.systemGray6))
+        .cornerRadius(16)
+    }
+}
+
+#Preview {
+    SimilarColorCard(
+        colorInfo: ColorInfo(name: "Gamboge", hexValue: "#E49B0F", description: "", category: .yellows),
+        baseColor: ColorInfo(name: "Indian Yellow", hexValue: "#E3B505", description: "", category: .yellows)
+    )
+}

--- a/HueKnewTests/ColorDatabaseTests.swift
+++ b/HueKnewTests/ColorDatabaseTests.swift
@@ -92,8 +92,20 @@ final class ColorDatabaseTests: XCTestCase {
     func testTemperatureCategory() {
         let color = ColorInfo(name: "Cyan", hexValue: "#00FFFF", description: "", category: .blues)
         let temperature = colorDatabase.temperatureCategory(for: color)
-        
+
         XCTAssertEqual(temperature, "cool", "Cyan should be classified as a cool color")
+    }
+
+    func testGetMostSimilarColors() {
+        let allColors = colorDatabase.getAllColors()
+        guard let firstColor = allColors.first else {
+            XCTFail("No colors loaded")
+            return
+        }
+
+        let similar = colorDatabase.getMostSimilarColors(to: firstColor, count: 2)
+        XCTAssertEqual(similar.count, 2)
+        XCTAssertFalse(similar.contains(firstColor))
     }
 }
 

--- a/HueKnewTests/ColorDatabaseTests.swift
+++ b/HueKnewTests/ColorDatabaseTests.swift
@@ -121,5 +121,19 @@ final class ColorDatabaseTests: XCTestCase {
         let comparisons = colorDatabase.getColorComparisons(color1: burnt, color2: terra)
         XCTAssertFalse(comparisons.isEmpty, "Burnt Sienna and Terra Cotta should have distinguishing characteristics")
     }
+
+    func testCarnelianVsFirebrickComparisons() {
+        let colors = colorDatabase.getAllColors()
+        guard
+            let carnelian = colors.first(where: { $0.name == "Carnelian" }),
+            let firebrick = colors.first(where: { $0.name == "Firebrick" })
+        else {
+            XCTFail("Required colors not found")
+            return
+        }
+
+        let comparisons = colorDatabase.getColorComparisons(color1: carnelian, color2: firebrick)
+        XCTAssertFalse(comparisons.isEmpty, "Carnelian and Firebrick should have distinguishing characteristics")
+    }
 }
 

--- a/HueKnewTests/ColorDatabaseTests.swift
+++ b/HueKnewTests/ColorDatabaseTests.swift
@@ -107,5 +107,19 @@ final class ColorDatabaseTests: XCTestCase {
         XCTAssertEqual(similar.count, 2)
         XCTAssertFalse(similar.contains(firstColor))
     }
+
+    func testComparisonsBetweenSimilarReds() {
+        let colors = colorDatabase.getAllColors()
+        guard
+            let burnt = colors.first(where: { $0.name == "Burnt Sienna" }),
+            let terra = colors.first(where: { $0.name == "Terra Cotta" })
+        else {
+            XCTFail("Required colors not found")
+            return
+        }
+
+        let comparisons = colorDatabase.getColorComparisons(color1: burnt, color2: terra)
+        XCTAssertFalse(comparisons.isEmpty, "Burnt Sienna and Terra Cotta should have distinguishing characteristics")
+    }
 }
 


### PR DESCRIPTION
## Summary
- suggest similar colors in detail view
- compute most similar colors in `ColorDatabase`
- compact card for showing similar colors
- add unit test for the new helper

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68747350dbf88330b596e241235bfc51