### PR TITLE
Inline feedback for swatch‑to‑name mistakes

### DIFF
--- a/HueKnew/Views/ChallengeView.swift
+++ b/HueKnew/Views/ChallengeView.swift
@@ -33,8 +33,21 @@ struct ChallengeView: View {
                     // Answer options
                     answerOptionsSection
                     
-                    // Submit button
-                    if selectedAnswer != nil && !showingResult {
+                    // Submit or continue button
+                    if showInlineIncorrect {
+                        Button(action: { onAnswerSelected(false) }) {
+                            Text("Continue")
+                                .font(.title2)
+                                .fontWeight(.bold)
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.orange)
+                                .cornerRadius(12)
+                        }
+                        .padding(.horizontal)
+                        .animation(.easeInOut(duration: 0.3), value: showInlineIncorrect)
+                    } else if selectedAnswer != nil && !showingResult {
                         Button(action: submitAnswer) {
                             Text("Submit Answer")
                                 .font(.title2)
@@ -266,9 +279,6 @@ struct ChallengeView: View {
         let isCorrect = selectedAnswer?.name == targetColor?.name
         if challengeType == .colorToName && !isCorrect {
             showInlineIncorrect = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + autoAdvanceDelay) {
-                onAnswerSelected(isCorrect)
-            }
         } else {
             showingResult = true
         }

--- a/HueKnew/Views/ChallengeView.swift
+++ b/HueKnew/Views/ChallengeView.swift
@@ -155,7 +155,8 @@ struct ChallengeView: View {
                             colorInfo: colorInfo,
                             isSelected: selectedAnswer?.name == colorInfo.name,
                             showSwatch: showInlineIncorrect,
-                            borderColor: showInlineIncorrect ? borderColor(for: colorInfo) : nil
+                            borderColor: showInlineIncorrect ? borderColor(for: colorInfo) : nil,
+                            showIncorrectIcon: showInlineIncorrect && selectedAnswer?.name == colorInfo.name
                         ) {
                             selectedAnswer = colorInfo
                         }
@@ -334,6 +335,7 @@ struct NameOptionCard: View {
     let isSelected: Bool
     let showSwatch: Bool
     let borderColor: Color?
+    let showIncorrectIcon: Bool
     let onTap: () -> Void
 
     var body: some View {
@@ -353,8 +355,8 @@ struct NameOptionCard: View {
                 Spacer()
 
                 if isSelected {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.blue)
+                    Image(systemName: showIncorrectIcon ? "xmark.circle.fill" : "checkmark.circle.fill")
+                        .foregroundColor(showIncorrectIcon ? .red : .blue)
                 }
             }
             .padding()


### PR DESCRIPTION
## Summary
- show a color swatch next to each name choice when a swatch-to-name answer is wrong
- highlight the correct answer without showing the modal overlay

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68751a3971cc8330b66206d58203cf1a