### PR TITLE
Add photo color identification view

### DIFF
--- a/HueKnew/ContentView.swift
+++ b/HueKnew/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
     @State private var gameModel = GameModel()
     @State private var showingSettings = false
     @State private var showingColorDictionary = false
+    @State private var showingPhotoPicker = false
 
     var body: some View {
         NavigationView {
@@ -19,7 +20,8 @@ struct ContentView: View {
                 FooterView(
                     onHome: { gameModel.goToMenu() },
                     onSettings: { showingSettings = true },
-                    onCatalog: { showingColorDictionary = true }
+                    onCatalog: { showingColorDictionary = true },
+                    onCamera: { showingPhotoPicker = true }
                 )
                 .safeAreaPadding(.bottom)
             }
@@ -30,6 +32,9 @@ struct ContentView: View {
             }
             .sheet(isPresented: $showingColorDictionary) {
                 ColorDictionaryView()
+            }
+            .sheet(isPresented: $showingPhotoPicker) {
+                PhotoColorPickerView()
             }
         }
     }

--- a/HueKnew/Data/ColorDatabase.swift
+++ b/HueKnew/Data/ColorDatabase.swift
@@ -456,6 +456,36 @@ extension ColorDatabase {
             return order[index == 0 ? order.count - 2 : index - 1]
         }
     }
+
+    // MARK: - Closest Color Helpers
+    func calculateColorDifference(hsb1: (hue: Double, saturation: Double, brightness: Double), color2: ColorInfo) -> Double {
+        let hsb2 = color2.hsbComponents
+
+        let hueDiff = min(abs(hsb1.hue - hsb2.hue), 360 - abs(hsb1.hue - hsb2.hue))
+        let normalizedHueDiff = hueDiff / 360.0
+
+        let satDiff = abs(hsb1.saturation - hsb2.saturation)
+        let brightDiff = abs(hsb1.brightness - hsb2.brightness)
+
+        let weightedDifference = (normalizedHueDiff * 0.6) + (satDiff * 0.25) + (brightDiff * 0.15)
+        return weightedDifference * 100.0
+    }
+
+    func getClosestColor(to uiColor: UIColor) -> ColorInfo? {
+        let hsb1 = uiColor.hsbComponents
+        var best: (color: ColorInfo, diff: Double)?
+
+        for color in getAllColors() {
+            let diff = calculateColorDifference(hsb1: hsb1, color2: color)
+            if let currentBest = best {
+                if diff < currentBest.diff { best = (color, diff) }
+            } else {
+                best = (color, diff)
+            }
+        }
+
+        return best?.color
+    }
 }
 
 extension ColorPair {

--- a/HueKnew/Views/FooterView.swift
+++ b/HueKnew/Views/FooterView.swift
@@ -11,6 +11,7 @@ struct FooterView: View {
     let onHome: () -> Void
     let onSettings: () -> Void
     let onCatalog: () -> Void
+    let onCamera: () -> Void
     
     var body: some View {
         HStack {
@@ -50,6 +51,19 @@ struct FooterView: View {
                 }
             }
             .frame(maxWidth: .infinity)
+
+            Spacer()
+
+            // Camera button
+            Button(action: onCamera) {
+                VStack {
+                    Image(systemName: "camera")
+                        .font(.title2)
+                    Text("Photo")
+                        .font(.caption)
+                }
+            }
+            .frame(maxWidth: .infinity)
         }
         .background(Color(.systemGray6))
     }
@@ -59,7 +73,8 @@ struct FooterView: View {
     FooterView(
         onHome: { print("Home tapped") },
         onSettings: { print("Settings tapped") },
-        onCatalog: { print("Catalog tapped") }
+        onCatalog: { print("Catalog tapped") },
+        onCamera: {}
     )
     .padding()
 }

--- a/HueKnew/Views/PhotoColorPickerView.swift
+++ b/HueKnew/Views/PhotoColorPickerView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+import PhotosUI
+
+struct PhotoColorPickerView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var pickerItem: PhotosPickerItem?
+    @State private var image: UIImage?
+    @State private var selectedColor: ColorInfo?
+    @State private var showingCamera = false
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                if let image = image {
+                    SelectableImageView(image: image) { uiColor in
+                        if let match = ColorDatabase.shared.getClosestColor(to: uiColor) {
+                            selectedColor = match
+                        }
+                    }
+                    .frame(maxHeight: 300)
+                } else {
+                    Spacer()
+                    Text("Select or capture a photo to begin")
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+
+                if let colorInfo = selectedColor {
+                    VStack(spacing: 12) {
+                        Rectangle()
+                            .fill(Color(hex: colorInfo.hexValue))
+                            .frame(width: 120, height: 120)
+                            .cornerRadius(12)
+                            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.white, lineWidth: 2))
+                        Text(colorInfo.name)
+                            .font(.title2)
+                            .fontWeight(.bold)
+                    }
+                    .padding()
+                }
+
+                Spacer()
+            }
+            .navigationTitle("Identify Color")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Close") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    PhotosPicker(selection: $pickerItem, matching: .images) {
+                        Image(systemName: "photo")
+                    }
+                }
+                ToolbarItem(placement: .bottomBar) {
+                    Button {
+                        showingCamera = true
+                    } label: {
+                        Label("Camera", systemImage: "camera")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingCamera) {
+                ImagePicker(image: $image, sourceType: .camera)
+            }
+            .onChange(of: pickerItem) { newItem in
+                if let newItem {
+                    Task {
+                        if let data = try? await newItem.loadTransferable(type: Data.self),
+                           let uiImage = UIImage(data: data) {
+                            image = uiImage
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct SelectableImageView: View {
+    let image: UIImage
+    var onColorSelected: (UIColor) -> Void
+
+    var body: some View {
+        GeometryReader { geometry in
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onEnded { value in
+                            let scaleX = image.size.width / geometry.size.width
+                            let scaleY = image.size.height / geometry.size.height
+                            let point = CGPoint(x: value.location.x * scaleX, y: value.location.y * scaleY)
+                            if let color = image.pixelColor(at: point) {
+                                onColorSelected(color)
+                            }
+                        }
+                )
+        }
+    }
+}
+
+struct ImagePicker: UIViewControllerRepresentable {
+    @Environment(\.presentationMode) var presentationMode
+    @Binding var image: UIImage?
+    var sourceType: UIImagePickerController.SourceType = .photoLibrary
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: ImagePicker
+        init(_ parent: ImagePicker) { self.parent = parent }
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let uiImage = info[.originalImage] as? UIImage {
+                parent.image = uiImage
+            }
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = sourceType
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+}
+
+extension UIImage {
+    func pixelColor(at point: CGPoint) -> UIColor? {
+        guard let cgImage = self.cgImage,
+              let dataProvider = cgImage.dataProvider,
+              let data = dataProvider.data else { return nil }
+        let dataPtr = CFDataGetBytePtr(data)
+        let bytesPerRow = cgImage.bytesPerRow
+        let bytesPerPixel = cgImage.bitsPerPixel / 8
+        let x = Int(point.x)
+        let y = Int(point.y)
+        guard x >= 0, x < cgImage.width, y >= 0, y < cgImage.height else { return nil }
+        let offset = y * bytesPerRow + x * bytesPerPixel
+        let r = dataPtr[offset]
+        let g = dataPtr[offset + 1]
+        let b = dataPtr[offset + 2]
+        let a = dataPtr[offset + 3]
+        return UIColor(red: CGFloat(r)/255.0, green: CGFloat(g)/255.0, blue: CGFloat(b)/255.0, alpha: CGFloat(a)/255.0)
+    }
+}
+
+extension UIColor {
+    var hsbComponents: (hue: Double, saturation: Double, brightness: Double) {
+        var h: CGFloat = 0
+        var s: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        return (Double(h) * 360.0, Double(s), Double(b))
+    }
+}
+
+#Preview {
+    PhotoColorPickerView()
+}

--- a/HueKnewTests/ColorDatabaseTests.swift
+++ b/HueKnewTests/ColorDatabaseTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 @testable import HueKnew
 
 final class ColorDatabaseTests: XCTestCase {
@@ -120,6 +121,12 @@ final class ColorDatabaseTests: XCTestCase {
 
         let comparisons = colorDatabase.getColorComparisons(color1: burnt, color2: terra)
         XCTAssertFalse(comparisons.isEmpty, "Burnt Sienna and Terra Cotta should have distinguishing characteristics")
+    }
+
+    func testClosestColorToPureRed() {
+        let red = UIColor.red
+        let closest = colorDatabase.getClosestColor(to: red)
+        XCTAssertNotNil(closest)
     }
 
     func testCarnelianVsFirebrickComparisons() {


### PR DESCRIPTION
## Summary
- add camera button in `FooterView`
- open new `PhotoColorPickerView` from `ContentView`
- implement color matching utilities in `ColorDatabase`
- provide `PhotoColorPickerView` with image picker and tap-to-identify
- test closest color helper

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68758b11d45c833091b261dc84457f29