### PR TITLE
Add color vision test

### DIFF
--- a/HueKnew/Models/GameModel.swift
+++ b/HueKnew/Models/GameModel.swift
@@ -42,11 +42,13 @@ class GameModel {
     // Game flow control
     var isGameActive: Bool = false
     var isPaused: Bool = false
+    var hasColorVisionDeficiency: Bool = UserDefaults.standard.bool(forKey: "colorVisionDeficiency")
     
     private let colorDatabase = ColorDatabase.shared
     
     init() {
-        // No debug logic
+        // Load color vision data if available
+        hasColorVisionDeficiency = UserDefaults.standard.bool(forKey: "colorVisionDeficiency")
     }
     
     // MARK: - Game Flow Methods
@@ -135,6 +137,9 @@ class GameModel {
         } else {
             availablePairs = colorDatabase.getAllColorPairs()
         }
+        if hasColorVisionDeficiency {
+            availablePairs = availablePairs.filter { $0.difficultyLevel == .easy }
+        }
         let unmasteredPairs = availablePairs.filter { !masteredPairs.contains($0.id) }
         if !unmasteredPairs.isEmpty {
             currentColorPair = unmasteredPairs.randomElement()
@@ -156,10 +161,16 @@ class GameModel {
     private func updateLevel() {
         // Level up based on accuracy and total questions answered
         let accuracy = totalQuestionsAnswered > 0 ? Double(correctAnswers) / Double(totalQuestionsAnswered) : 0
-        
+
         if accuracy >= 0.8 && totalQuestionsAnswered >= level * 20 {
             level += 1
         }
+    }
+
+    // MARK: - Color Vision Support
+    func setColorVisionDeficiency(_ value: Bool) {
+        hasColorVisionDeficiency = value
+        UserDefaults.standard.set(value, forKey: "colorVisionDeficiency")
     }
     
     // MARK: - Statistics

--- a/HueKnew/Views/ColorVisionTestView.swift
+++ b/HueKnew/Views/ColorVisionTestView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct VisionQuestion {
+    let prompt: String
+    let colors: [Color]
+    let correctIndex: Int
+}
+
+struct ColorVisionTestView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var questionIndex = 0
+    @State private var correctAnswers = 0
+
+    let completion: (Bool) -> Void
+
+    private let questions: [VisionQuestion] = [
+        VisionQuestion(prompt: "Select the green color", colors: [.red, .green], correctIndex: 1),
+        VisionQuestion(prompt: "Select the blue color", colors: [.blue, .orange], correctIndex: 0),
+        VisionQuestion(prompt: "Select the purple color", colors: [.yellow, .purple], correctIndex: 1)
+    ]
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Text(questions[questionIndex].prompt)
+                .font(.title2)
+                .multilineTextAlignment(.center)
+                .padding()
+
+            HStack(spacing: 40) {
+                ForEach(0..<questions[questionIndex].colors.count, id: \.self) { index in
+                    Circle()
+                        .fill(questions[questionIndex].colors[index])
+                        .frame(width: 100, height: 100)
+                        .onTapGesture {
+                            handleAnswer(index)
+                        }
+                }
+            }
+        }
+    }
+
+    private func handleAnswer(_ index: Int) {
+        if index == questions[questionIndex].correctIndex {
+            correctAnswers += 1
+        }
+        if questionIndex + 1 < questions.count {
+            questionIndex += 1
+        } else {
+            let hasDeficiency = correctAnswers < questions.count
+            completion(hasDeficiency)
+            dismiss()
+        }
+    }
+}
+
+#Preview {
+    ColorVisionTestView { _ in }
+}

--- a/HueKnew/Views/SettingsView.swift
+++ b/HueKnew/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var audioManager = AudioManager.shared
     @State private var showingResetAlert = false
+    @State private var showingVisionTest = false
 
     private static let versionKey = "CFBundleShortVersionString"
     private static let buildKey = "CFBundleVersion"
@@ -41,6 +42,19 @@ struct SettingsView: View {
                         showingResetAlert = true
                     }
                     .foregroundColor(.red)
+                }
+
+                Section("Accessibility") {
+                    Button("Color Vision Test") {
+                        showingVisionTest = true
+                    }
+                    .foregroundColor(.blue)
+
+                    if gameModel.hasColorVisionDeficiency {
+                        Text("Color vision assistance enabled")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
                 }
                 
                 Section("About") {
@@ -74,6 +88,11 @@ struct SettingsView: View {
                 }
             } message: {
                 Text("This will reset all your game progress including score, level, streak, and mastered colors. This action cannot be undone.")
+            }
+            .sheet(isPresented: $showingVisionTest) {
+                ColorVisionTestView { result in
+                    gameModel.setColorVisionDeficiency(result)
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The game uses a progressive learning approach with two main phases:
 - **Smart color pairs**: Curated color combinations that are commonly confused
 - **Achievement system**: Track your progress and unlock new color categories
 - **Streak tracking**: Monitor your learning momentum
+- **Color vision test**: Optional accessibility test to adapt challenges
 - **Category-based learning**: Focus on specific color families (blues, yellows, reds, etc.)
 
 ## 🎨 Color Categories


### PR DESCRIPTION
## Summary
- add a simple `ColorVisionTestView`
- store color vision deficiency in `GameModel`
- filter advanced color pairs if color deficiency detected
- hook up a new button in Settings to run the test
- document the feature in README

## Testing
- `swift --version`
- `sudo apt-get install -y swiftlint` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6876b57f51888330b865aa67b7f6fd1c