### PR TITLE
Support codex branch deployments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - testflight
+      - 'codex/**'
 
 env:
   IPHONEOS_DEPLOYMENT_TARGET: ${{ vars.IPHONEOS_DEPLOYMENT_TARGET }}

--- a/HueKnew/Views/CameraColorPickerView.swift
+++ b/HueKnew/Views/CameraColorPickerView.swift
@@ -37,7 +37,13 @@ struct CameraColorPickerView: View {
                 contentView(sampleGesture: sampleGesture)
                     .ignoresSafeArea(edges: .top)
 
-                if let baseImage = currentImage, showSelector {
+                if mode == .ar {
+                    Rectangle()
+                        .stroke(Color.white, lineWidth: 2)
+                        .frame(width: 80, height: 80)
+                }
+
+                if let baseImage = currentImage, showSelector, mode != .ar {
                     MagnifierView(image: baseImage, imagePoint: imagePoint)
                         .frame(width: 120, height: 120)
                         .position(x: touchLocation.x, y: max(CGFloat(60), touchLocation.y - 150))
@@ -54,6 +60,12 @@ struct CameraColorPickerView: View {
                         .padding(.bottom, geo.safeAreaInsets.bottom + 8)
                 }
                 .padding(.horizontal)
+            }
+            .onChange(of: liveFrame) { _ in
+                if mode == .ar {
+                    let center = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
+                    updateColor(at: center, in: geo)
+                }
             }
         }
         .onChange(of: mode) { _, newMode in
@@ -79,7 +91,6 @@ struct CameraColorPickerView: View {
         Group {
             if mode == .ar {
                 LiveCameraView(frame: $liveFrame)
-                    .gesture(sampleGesture)
             } else if let img = image {
                 Image(uiImage: img)
                     .resizable()


### PR DESCRIPTION
## Summary
- update AR view to show a fixed center square for live color sampling
- trigger TestFlight CD workflow on `codex/**` branches

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879617907ac83309429da1bdb87cb8b