### PR TITLE
Fix color sampling for BGRA images

### DIFF
--- a/HueKnew/Views/CameraColorPickerView.swift
+++ b/HueKnew/Views/CameraColorPickerView.swift
@@ -20,6 +20,9 @@ struct CameraColorPickerView: View {
     @State private var nearbyColors: [ColorInfo] = []
     @State private var lastARUpdate = Date()
     private let arUpdateInterval: TimeInterval = 0.6
+    /// Size of the square sampled when determining a color
+    /// One pixel larger than the on-screen indicator to avoid rounding issues
+    private let sampleSize: CGFloat = 9
     @State private var showSelector = false
     @State private var imagePoint: CGPoint = .zero
     private let colorDatabase = ColorDatabase.shared
@@ -113,7 +116,11 @@ struct CameraColorPickerView: View {
     }
 
     private var currentImage: UIImage? {
-        if mode == .ar { return liveFrame } else { return image }
+        if mode == .ar {
+            return liveFrame
+        } else {
+            return image?.normalizedOrientation()
+        }
     }
 
     private func updateColor(at location: CGPoint, in geo: GeometryProxy) {
@@ -122,7 +129,11 @@ struct CameraColorPickerView: View {
         imagePoint = imgPoint
 
         DispatchQueue.global(qos: .userInitiated).async {
-            if let uiColor = img.color(at: imgPoint) {
+            let intSize = Int(sampleSize)
+            let x = Int(round(imgPoint.x)) - intSize / 2
+            let y = Int(round(imgPoint.y)) - intSize / 2
+            let rect = CGRect(x: x, y: y, width: intSize, height: intSize)
+            if let uiColor = img.averageColor(in: rect) {
                 let hsb = uiColor.hsbComponents
                 let matches = self.colorDatabase.nearestColors(
                     hue: hsb.hue,
@@ -292,7 +303,7 @@ class CameraController: UIViewController, AVCaptureVideoDataOutputSampleBufferDe
         let ciImage = CIImage(cvPixelBuffer: buffer)
         if let cgImage = context.createCGImage(ciImage, from: ciImage.extent) {
             let frameImage = UIImage(cgImage: cgImage, scale: 1.0, orientation: .right)
-            delegate?.didOutput(image: frameImage)
+            delegate?.didOutput(image: frameImage.normalizedOrientation())
         }
     }
 }
@@ -328,6 +339,10 @@ private extension UIImage {
         guard let cgImage else { return nil }
         return cgImage.color(at: point)
     }
+    func averageColor(in rect: CGRect) -> UIColor? {
+        guard let cgImage else { return nil }
+        return cgImage.averageColor(in: rect)
+    }
     func normalizedOrientation() -> UIImage {
         if imageOrientation == .up { return self }
         UIGraphicsBeginImageContextWithOptions(size, false, scale)
@@ -340,20 +355,70 @@ private extension UIImage {
 }
 
 private extension CGImage {
+    struct ChannelOffsets { let r: Int; let g: Int; let b: Int; let a: Int }
+
+    var channelOffsets: ChannelOffsets {
+        let info = bitmapInfo
+        let alphaInfo = CGImageAlphaInfo(rawValue: info.rawValue & CGBitmapInfo.alphaInfoMask.rawValue)
+        let littleEndian = info.contains(.byteOrder32Little)
+        switch (alphaInfo, littleEndian) {
+        case (.premultipliedFirst, true), (.first, true), (.noneSkipFirst, true):
+            return ChannelOffsets(r: 2, g: 1, b: 0, a: 3) // BGRA
+        default:
+            return ChannelOffsets(r: 0, g: 1, b: 2, a: 3) // Assume RGBA
+        }
+    }
     func color(at point: CGPoint) -> UIColor? {
         guard let dataProvider = dataProvider,
               let data = dataProvider.data,
               let pixelData = CFDataGetBytePtr(data) else { return nil }
         let bytesPerPixel = 4
-        let bytesPerRow = bytesPerPixel * width
+        let bytesPerRow = self.bytesPerRow
         let x = Int(point.x)
         let y = Int(point.y)
         guard x >= 0, y >= 0, x < width, y < height else { return nil }
+        let offsets = channelOffsets
         let index = y * bytesPerRow + x * bytesPerPixel
-        let r = CGFloat(pixelData[index]) / 255.0
-        let g = CGFloat(pixelData[index + 1]) / 255.0
-        let b = CGFloat(pixelData[index + 2]) / 255.0
-        let a = CGFloat(pixelData[index + 3]) / 255.0
+        let r = CGFloat(pixelData[index + offsets.r]) / 255.0
+        let g = CGFloat(pixelData[index + offsets.g]) / 255.0
+        let b = CGFloat(pixelData[index + offsets.b]) / 255.0
+        let a = CGFloat(pixelData[index + offsets.a]) / 255.0
+        return UIColor(red: r, green: g, blue: b, alpha: a)
+    }
+
+    func averageColor(in rect: CGRect) -> UIColor? {
+        guard rect.width > 0, rect.height > 0 else { return nil }
+        guard let dataProvider = dataProvider,
+              let data = dataProvider.data,
+              let pixelData = CFDataGetBytePtr(data) else { return nil }
+        let bytesPerPixel = 4
+        let bytesPerRow = self.bytesPerRow
+        let offsets = channelOffsets
+        let x0 = max(Int(rect.minX), 0)
+        let y0 = max(Int(rect.minY), 0)
+        let x1 = min(Int(rect.maxX - 1), width - 1)
+        let y1 = min(Int(rect.maxY - 1), height - 1)
+        guard x1 >= x0, y1 >= y0 else { return nil }
+        var rTotal: Int = 0
+        var gTotal: Int = 0
+        var bTotal: Int = 0
+        var aTotal: Int = 0
+        var count: Int = 0
+        for y in y0...y1 {
+            for x in x0...x1 {
+                let index = y * bytesPerRow + x * bytesPerPixel
+                rTotal += Int(pixelData[index + offsets.r])
+                gTotal += Int(pixelData[index + offsets.g])
+                bTotal += Int(pixelData[index + offsets.b])
+                aTotal += Int(pixelData[index + offsets.a])
+                count += 1
+            }
+        }
+        guard count > 0 else { return nil }
+        let r = CGFloat(rTotal) / CGFloat(count) / 255.0
+        let g = CGFloat(gTotal) / CGFloat(count) / 255.0
+        let b = CGFloat(bTotal) / CGFloat(count) / 255.0
+        let a = CGFloat(aTotal) / CGFloat(count) / 255.0
         return UIColor(red: r, green: g, blue: b, alpha: a)
     }
 }


### PR DESCRIPTION
## Summary
- handle BGRA pixel order when reading camera frames
- average color uses correct channel offsets